### PR TITLE
Fix: Enable editor scrollbar by removing global overflow:hidden

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -50,7 +50,7 @@
 	width: 100vw;
 	margin: 0;
 	padding: 0;
-	overflow: hidden;
+	/* overflow: hidden; */ /* Removed to allow editor scrollbar */
 	background-color: var(--tt-bg-color, #ffffff);
 	color: var(--tt-theme-text, #000000);
 }
@@ -61,7 +61,7 @@ html, body, #root {
 	width: 100%;
 	margin: 0;
 	padding: 0;
-	overflow: hidden;
+	/* overflow: hidden; */ /* Removed to allow editor scrollbar */
 }
 
 /* Dark mode support */


### PR DESCRIPTION
The scrollbar for the Tiptap editor was not appearing because `overflow: hidden` was set on `html`, `body`, `#root`, and the main `.app-container` in `src/App.css`.

This change removes these `overflow: hidden` rules, allowing the `overflow-y: auto` property on the editor's `.content-wrapper` (defined in `simple-editor.scss`) to take effect and display a scrollbar when the content is taller than the viewport.